### PR TITLE
Fix interpreter mistreating complex executable names

### DIFF
--- a/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
+++ b/src/it/scala/smtlib/it/ProcessInterpreterTests.scala
@@ -18,6 +18,15 @@ class ProcessInterpreterTests extends AnyFunSuite with TestHelpers {
   //TODO: properly get all interpreters
   def interpreters: Seq[Interpreter] = Seq(getZ3Interpreter)
 
+  test("Interpreter can be created with complex executable names") {
+    // sometimes we are given arguments in the executable name itself;
+    // check that these are split and processed correctly
+    val z3Interpreter = new Z3Interpreter("z3 -in", Array("-smt2")) {}
+    z3Interpreter.eval(trees.Commands.SetLogic(trees.Commands.AUFLIA()))
+    z3Interpreter.eval(trees.Commands.CheckSat())
+    z3Interpreter.interrupt()
+  }
+
   test("Interrupt after free does not throw an exception") {
     //TODO: check against all interpreters
     val z3Interpreter = getZ3Interpreter

--- a/src/main/scala/smtlib/interpreters/ProcessInterpreter.scala
+++ b/src/main/scala/smtlib/interpreters/ProcessInterpreter.scala
@@ -130,7 +130,13 @@ object ProcessInterpreter {
   private def ctorHelper(executable: String,
                          args: Array[String],
                          parserCtor: BufferedReader => Parser): (Parser, Process, BufferedWriter, BufferedReader, BufferedReader) = {
-    val process = java.lang.Runtime.getRuntime.exec(executable +: args)
+    val (executableName, implicitArgs) = if (executable.contains(" ")) {
+      val parts = executable.split(" ")
+      (parts(0), parts.drop(1))
+    } else {
+      (executable, Array.empty[String])
+    }
+    val process = java.lang.Runtime.getRuntime.exec(executableName +: (implicitArgs ++ args))
     val in = new BufferedWriter(new OutputStreamWriter(process.getOutputStream))
     val out = new BufferedReader(new InputStreamReader(process.getInputStream))
     val err = new BufferedReader(new InputStreamReader(process.getErrorStream))


### PR DESCRIPTION
Due to a recent change (1f0b4a9d), the process interpreter would be _too restrictive_ and mistreat executable names containing arguments, e.g. "z3 -in -smt2" provided as a string. This PR fixes this behaviour by checking for this and splitting the arguments before constructing the interpreter. A unit test for the same is added.